### PR TITLE
ci: translate GitHub release notes to English

### DIFF
--- a/.github/release-notes/v0.7.6.md
+++ b/.github/release-notes/v0.7.6.md
@@ -1,0 +1,18 @@
+## What's new in v0.7.6
+
+### New
+- **Visual trigger routing lines** — Each trigger now connects directly to its associated condition in `choose:` blocks
+- Invisible choose-chain edges for technically correct transpilation without visual noise
+
+### Bug Fixes
+- `id:` field in the properties panel was empty for the HA API format → now normalized correctly
+- Edge type was discarded on import/export
+- Fixed gray arrow overlap effect on nodes
+- Topology analyzer now ignores visual edges
+
+### Improvements
+- ELK layout: clean 3-column layout (Triggers | Conditions | Actions)
+- `fitView` after import more reliable (150ms, maxZoom 0.75)
+
+---
+Full changelog: [CHANGELOG.md](https://github.com/SH1FT-W/flode/blob/main/CHANGELOG.md)

--- a/.github/release-notes/v0.7.7.md
+++ b/.github/release-notes/v0.7.7.md
@@ -1,0 +1,19 @@
+## Bug Fixes
+
+- **Import crash with `conditions: []`** — Choose cases with an empty conditions array (valid HA syntax for empty default branches) caused an `undefined is not an object` crash on import
+- **Red dot on while condition** — The FALSE handle on the condition node is now only shown when an edge is actually attached to it; with `repeat:while:` the misleading red dot disappears
+- **Loop arrow as dashed line** — Back edges for `repeat:while/until/count` are rendered as a dashed arrow so the loop character is recognizable at a glance
+
+## Repo Cleanup
+
+- Switched all remaining `cafe_*` references to FLODE (localStorage keys, window globals, postMessage events)
+- Removed unguarded `console.log` calls from production code
+- `manifest.json`: `iot_class` → `calculated`, removed invalid `documentation_url`
+- `hacs.json`: added `"domain": "flode"`
+- HACS validation now runs automatically on push/PR
+
+## Installation
+
+**HACS (recommended):** [![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=SH1FT-W&repository=flode&category=integration)
+
+**Manual:** Download `flode.zip`, extract to `config/custom_components/flode/`

--- a/.github/release-notes/v0.7.9.md
+++ b/.github/release-notes/v0.7.9.md
@@ -1,0 +1,16 @@
+## What's new
+
+### Bug Fixes
+- **Crossed lines in trigger-based choose blocks** — Automations with multiple triggers and trigger-ID conditions (e.g. the iPad battery automation) showed crossed blue lines because all triggers were connected to the first case. Now each trigger only connects to its matching case (via hint edge). The internal flow edges are invisible.
+- **Backward detection too sensitive** — Minimal x differences in stored metadata triggered unnecessary layout recalculations; threshold raised to 100 px.
+
+### Includes all fixes from v0.7.8
+- Choose-block visualization (3 lines from the entry point, default connected)
+- Restored the red FALSE handle on condition nodes
+- Bézier curves for all connection lines
+
+## Installation
+
+**HACS:** Update repository → reinstall FLODE → restart HA
+
+**Manual:** Download `flode.zip`, extract, copy the `flode/` folder to `config/custom_components/flode/` → restart HA

--- a/.github/release-notes/v0.8.0.md
+++ b/.github/release-notes/v0.8.0.md
@@ -1,0 +1,5 @@
+## What's new in v0.8.0
+
+- **Stability** — various minor bug fixes and improvements
+- **Screenshots in the README** — preview of the app in light and dark mode at a glance
+- **Improved documentation** — both modes are shown side by side in the GitHub header

--- a/.github/release-notes/v0.9.0.md
+++ b/.github/release-notes/v0.9.0.md
@@ -1,0 +1,16 @@
+## What's new
+
+### OR/AND/NOT Container Nodes
+Group conditions now show their sub-conditions directly as mini cards inside the node — no more clicking needed to understand the logic.
+
+- The group type (OR / AND / NOT) is shown as a visual separator between the sub-condition cards
+- From 4+ sub-conditions, a "+X more" button appears to expand/collapse
+
+### Full i18n for all node cards
+All type labels in trigger, condition, action, delay, wait and SetVariables nodes are now displayed dynamically based on the selected language (previously hardcoded English).
+
+- Condition types: `State`, `Numeric State`, `OR (Any)`, `AND (All)`, etc.
+- Trigger platforms: `State change`, `Time`, `Event`, etc.
+- Fallback node titles: `Delay`, `Wait for`, `Set variables`, `Action`
+
+Closes #8

--- a/.github/release-notes/v0.9.1.md
+++ b/.github/release-notes/v0.9.1.md
@@ -1,0 +1,9 @@
+
+### Fixed
+- `ConfigFlowResult` instead of the deprecated `FlowResult` from `homeassistant.data_entry_flow` (deprecated since HA 2024.4)
+- Corrected the minimum HA version in `manifest.json` and `hacs.json` to `2024.6.0` (`StaticPathConfig` requires 2024.6)
+- Removed unused `import os` and the dead `PANEL_URL` constant from `panel.py`
+- Removed the empty `async_setup` function from `__init__.py` (not needed for config-flow integrations)
+- Replaced the hacky panel pre-removal via `hass.data` with clean lifecycle logic
+
+---

--- a/.github/release-notes/v0.9.2.md
+++ b/.github/release-notes/v0.9.2.md
@@ -1,0 +1,10 @@
+
+### Fixed
+- Fixed all Biome lint errors and formatting issues (19 files auto-formatted)
+- Set `type="button"` on collapse/expand buttons in `ConditionNode` (a11y)
+- Properly escaped JSX literals in `App.tsx` and `ConditionNode.tsx`
+- Fixed `noEmptyBlockStatements` in `App.tsx`
+- Set `aria-hidden="true"` on decorative SVG in `LoopBackEdge` (a11y)
+- `biome-ignore` comment for the unavoidably complex graph-traversal function in `native.ts`
+
+---

--- a/.github/release-notes/v0.9.4.md
+++ b/.github/release-notes/v0.9.4.md
@@ -1,0 +1,14 @@
+
+### Fixed
+- **Stop Action Node**: Stop nodes (`stop: "Message"`) are now rendered orange with an OctagonX icon instead of green like regular actions
+- **Stop Action Properties Panel**: Stop nodes now show the correct type "Stop Execution" in the panel, with a dedicated stop-message input and a "Mark as error" toggle
+- **Stop/Error in "Additional Properties"**: `stop` and `error` were incorrectly shown in the Additional Properties panel — now correctly configured as handled properties
+- **Top-level `variables:` round-trip** (C.A.F.E. #210): The `variables:` section at automation level is now preserved on YAML export — previously it was stripped out on export
+- **Version number in UI**: The `manifest.json` version had never been updated — all builds incorrectly showed "v0.9.2"
+
+### Added
+- i18n: `nodes:types.stop`, `nodes:actions.stopExecution`, `nodes:actions.stopError`, `nodes:actions.stopMessageLabel`, `nodes:actions.markAsError`, `nodes:actions.actionTypes.stop` (DE + EN)
+- Test fixture `34-toplevel-variables.yaml` for the variables round-trip
+- Tests: `toplevel-variables-roundtrip.test.ts` (3 tests)
+
+---

--- a/.github/release-notes/v0.9.5.md
+++ b/.github/release-notes/v0.9.5.md
@@ -1,0 +1,14 @@
+
+### Added
+- **Choose-Block Case Labels**: The first condition node of each choose case now shows an indigo pill badge ("Case 1/3", "Case 2/3", "Case 3/3") — makes it easier to visually distinguish multiple branches within the same choose block
+- **State dropdown in condition fields**: The state field in state conditions now shows a dropdown list of matching states for the selected entity (just like triggers)
+- **Translated state values**: State values are shown in the UI language (on→An, off→Aus, home→Zuhause, etc.) with an optional English suffix when values differ
+- **GitHub Actions Node.js 24**: All workflows now use `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` to avoid the Node.js 20 deprecation warning
+
+### Fixed
+- **react-error-boundary 6.1.x**: Fixed breaking change (`error: Error` → `error: unknown`) in `FallbackComponent`
+
+### Changed
+- Dependency updates (minor/patch): `@xyflow/react`, `zustand`, `react-hook-form`, `react-error-boundary`, `fuse.js`, all `@radix-ui/*`, `zod`, `elkjs`, `@biomejs/biome`, `turbo`, `tsx`, `glob`
+
+---

--- a/.github/release-notes/v0.9.6.md
+++ b/.github/release-notes/v0.9.6.md
@@ -1,0 +1,10 @@
+
+### Fixed
+- **#221 — Templated delay / wait timeout (object form)**: Delay and wait fields (`hours`, `minutes`, `seconds`, `milliseconds`) now accept `string | number` — template strings like `{{ states('input_number.delay_minutes') | int(5) }}` were previously rejected by Zod and prevented importing the automation
+- **#220 — Top-level automation keys lost on save**: `trigger_variables`, `initial_state: false` and `trace` were not written back on export. The cause was a hardcoded 7-field object in `createAutomation`/`updateAutomation` (ha-api.ts) that silently discarded all other keys. Fixed by fully spreading the config object
+
+### Tests
+- `issue-221-templated-delay.test.ts` (5 tests)
+- `issue-220-toplevel-keys-roundtrip.test.ts` (6 tests)
+
+---

--- a/.github/workflows/translate-releases.yml
+++ b/.github/workflows/translate-releases.yml
@@ -1,0 +1,53 @@
+name: Translate releases to English
+
+# Manually triggered one-off: rewrites the GitHub release notes that were
+# (partly) in German to English. Bodies live in .github/release-notes/<tag>.md,
+# titles are mapped below. Safe to delete this workflow (and the notes folder)
+# once the releases have been updated.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply English release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          declare -A TITLES=(
+            ["v0.9.6"]="v0.9.6 — Templated Delay & Top-Level Keys Round-Trip"
+            ["v0.9.5"]="v0.9.5 — Choose-Block Labels, State Dropdown & Dependency Updates"
+            ["v0.9.4"]="v0.9.4 — Stop Action & Variables Bugfixes"
+            ["v0.9.2"]="v0.9.2 — Lint & Code Quality"
+            ["v0.9.1"]="v0.9.1 — HA Integration Cleanup"
+            ["v0.9.0"]="v0.9.0 — OR/AND Condition Visualization & i18n"
+            ["v0.8.0"]="v0.8.0 — Screenshots & Documentation"
+            ["v0.7.9"]="v0.7.9 — Choose-Block Trigger Routing Fix"
+            ["v0.7.7"]="v0.7.7"
+            ["v0.7.6"]="v0.7.6 — Trigger Routing & Layout"
+          )
+
+          for f in .github/release-notes/*.md; do
+            tag="$(basename "$f" .md)"
+            title="${TITLES[$tag]:-}"
+            if [ -z "$title" ]; then
+              echo "::warning::No title mapping for $tag, skipping"
+              continue
+            fi
+            echo "Updating release $tag ..."
+            gh release edit "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$title" \
+              --notes-file "$f"
+          done
+
+          echo "Done."


### PR DESCRIPTION
## Why

The GitHub releases were inconsistent — some notes in English, most in German. This makes them all English, keeping each release's **structure identical** (headings, bullets, issue refs, code blocks); only the language changes.

## How

GitHub's `workflow_dispatch` only works when the workflow lives on the default branch, so the rewrite is driven by a one-off Actions workflow that has to be merged to `main` first.

- `.github/workflows/translate-releases.yml` — manually triggered (`workflow_dispatch`); runs `gh release edit <tag> --title … --notes-file …` for each release using the CI `GITHUB_TOKEN`.
- `.github/release-notes/<tag>.md` — the English bodies (v0.7.6, v0.7.7, v0.7.9, v0.8.0, v0.9.0, v0.9.1, v0.9.2, v0.9.4, v0.9.5, v0.9.6). v0.9.3 was already English and is left untouched.

## After merge

1. Run the **"Translate releases to English"** workflow from the Actions tab (or I can trigger it).
2. Verify the releases.
3. The workflow + `.github/release-notes/` folder can be removed again — they're only needed for this one-off rewrite.

https://claude.ai/code/session_01UjhSZ4tPb9JTe7ffpgjEso

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjhSZ4tPb9JTe7ffpgjEso)_