### PR TITLE
docs: fix HA min version (2024.6) and literal &mdash; on landing page

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -8,7 +8,7 @@
   <p><strong>Visueller Flow + Node Editor für Home Assistant</strong></p>
 
   [![Release](https://img.shields.io/badge/version-0.9.6-2F81F7?style=flat-square)](https://github.com/SH1FT-W/flode/releases/latest)
-  [![HA Version](https://img.shields.io/badge/HA-2024.1%2B-brightgreen?style=flat-square)](https://www.home-assistant.io)
+  [![HA Version](https://img.shields.io/badge/HA-2024.6%2B-brightgreen?style=flat-square)](https://www.home-assistant.io)
   [![Lizenz](https://img.shields.io/badge/lizenz-Apache%202.0-orange?style=flat-square)](LICENSE)
   [![Status](https://img.shields.io/badge/status-beta-yellow?style=flat-square)](https://github.com/SH1FT-W/flode/releases)
   [![Tests](https://img.shields.io/badge/tests-278%20passing-3FB950?style=flat-square)](https://github.com/SH1FT-W/flode/actions)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p><strong>Visual Flow + Node Editor for Home Assistant</strong></p>
 
   [![Release](https://img.shields.io/badge/version-0.9.6-2F81F7?style=flat-square)](https://github.com/SH1FT-W/flode/releases/latest)
-  [![HA Version](https://img.shields.io/badge/HA-2024.1%2B-brightgreen?style=flat-square)](https://www.home-assistant.io)
+  [![HA Version](https://img.shields.io/badge/HA-2024.6%2B-brightgreen?style=flat-square)](https://www.home-assistant.io)
   [![License](https://img.shields.io/badge/license-Apache%202.0-orange?style=flat-square)](LICENSE)
   [![Status](https://img.shields.io/badge/status-beta-yellow?style=flat-square)](https://github.com/SH1FT-W/flode/releases)
   [![Tests](https://img.shields.io/badge/tests-278%20passing-3FB950?style=flat-square)](https://github.com/SH1FT-W/flode/actions)

--- a/docs/index.html
+++ b/docs/index.html
@@ -288,7 +288,7 @@
 
   <div class="hero-badge">
     <span class="dot"></span>
-    <span class="version-tag">…</span> <span data-i18n="hero.badge">&mdash; actively developed</span>
+    <span class="version-tag">…</span> <span data-i18n="hero.badge">— actively developed</span>
   </div>
 
   <h1 data-i18n-html="hero.title">
@@ -313,7 +313,7 @@
 
   <div class="badge-row">
     <span class="pill pill-blue version-tag">…</span>
-    <span class="pill pill-green">HA 2024.1+</span>
+    <span class="pill pill-green">HA 2024.6+</span>
     <span class="pill pill-amber">Beta</span>
     <span class="pill pill-purple">Apache 2.0</span>
     <span class="pill pill-teal">HACS</span>
@@ -371,7 +371,7 @@
       </div>
     </div>
     <div class="flow-footer" data-i18n="flow.footer">
-      Saved as native Home Assistant YAML &mdash; directly in the HA core
+      Saved as native Home Assistant YAML — directly in the HA core
     </div>
   </div>
 </div>
@@ -552,7 +552,7 @@
       'nav.nodes': 'Nodes',
       'nav.installation': 'Installation',
       'nav.changelog': 'Changelog',
-      'hero.badge': '&mdash; actively developed',
+      'hero.badge': '— actively developed',
       'hero.title': 'Flows instead of<br/><span class="accent">YAML battles.</span>',
       'hero.sub': 'FLODE is a visual node editor for <strong>Home Assistant automations</strong> — inspired by Node-RED, but without an external server. Draw. Save. Done.',
       'hero.btnHacs': 'Open in HACS ↗',
@@ -567,7 +567,7 @@
       'flow.action2.text': 'Dim light to 30%',
       'flow.logic.type': 'End',
       'flow.logic.text': 'Done ✓',
-      'flow.footer': 'Saved as native Home Assistant YAML &mdash; directly in the HA core',
+      'flow.footer': 'Saved as native Home Assistant YAML — directly in the HA core',
       'flow.edge.yes': 'yes',
       'flow.edge.no': 'no',
       'yaml.left.label': 'Visual flow',
@@ -628,7 +628,7 @@
       'nav.nodes': 'Knoten',
       'nav.installation': 'Installation',
       'nav.changelog': 'Changelog',
-      'hero.badge': '&mdash; aktiv in Entwicklung',
+      'hero.badge': '— aktiv in Entwicklung',
       'hero.title': 'Flows statt<br/><span class="accent">YAML-Schlachten.</span>',
       'hero.sub': 'FLODE ist ein visueller Node-Editor für <strong>Home Assistant Automatisierungen</strong> — inspiriert von Node-RED, aber ohne externen Server. Zeichne. Speichere. Fertig.',
       'hero.btnHacs': 'In HACS öffnen ↗',
@@ -643,7 +643,7 @@
       'flow.action2.text': 'Licht auf 30 % dimmen',
       'flow.logic.type': 'Ende',
       'flow.logic.text': 'Fertig ✓',
-      'flow.footer': 'Wird gespeichert als natives Home Assistant YAML &mdash; direkt im HA-Kern',
+      'flow.footer': 'Wird gespeichert als natives Home Assistant YAML — direkt im HA-Kern',
       'flow.edge.yes': 'ja',
       'flow.edge.no': 'nein',
       'yaml.left.label': 'Visueller Flow',


### PR DESCRIPTION
Two small fixes to the docs that just shipped:

1. **HA minimum version** — the README badges and the landing-page pill showed `HA 2024.1+`, but the actual minimum is **2024.6** (`hacs.json` / `manifest.json`). Corrected to `2024.6+` in `README.md`, `README.de.md`, and `docs/index.html`.
2. **Literal `&mdash;`** — the hero badge ("… — actively developed") and the flow-demo footer rendered a literal `&mdash;` because those i18n strings are applied via `textContent`, which does not decode HTML entities. Replaced the entity with the real em-dash character `—` (both EN and DE).

https://claude.ai/code/session_01UjhSZ4tPb9JTe7ffpgjEso

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjhSZ4tPb9JTe7ffpgjEso)_